### PR TITLE
Create script to cleanup acorn database by clearing out old mailing e…

### DIFF
--- a/database_cleanup.drush
+++ b/database_cleanup.drush
@@ -1,0 +1,17 @@
+<?php
+
+$eventTables = [
+  "civicrm_mailing_event_bounce",
+  "civicrm_mailing_event_confirm",
+  "civicrm_mailing_event_delivered",
+  "civicrm_mailing_event_forward",
+  "civicrm_mailing_event_opened",
+  "civicrm_mailing_event_reply",
+  "civicrm_mailing_event_subscribe",
+  "civicrm_mailing_event_trackable_url_open",
+  "civicrm_mailing_event_unsubscribe",
+];
+foreach ($eventTables as $table) {
+  CRM_Core_DAO::executeQuery('DELETE e.* FROM ' . $table . ' e INNER JOIN civicrm_mailing_event_queue eq ON eq.id = e.event_queue_id INNER JOIN civicrm_mailing_job mj ON mj.id = eq.job_id INNER JOIN civicrm_mailing cm ON cm.id = mj.mailing_id WHERE cm.scheduled_date < date_sub(NOW(), INTERVAL 1 YEAR)');
+}
+CRM_Core_DAO::executeQuery('DELETE eq.* FROM civicrm_mailing_event_queue eq INNER JOIN civicrm_mailing_job mj ON mj.id = eq.job_id INNER JOIN civicrm_mailing cm ON cm.id = mj.mailing_id WHERE cm.scheduled_date < date_sub(NOW(), INTERVAL 1 YEAR)');


### PR DESCRIPTION
…vent data older than a year

@monishdeb can you review this and see what you think @JoeMurray I think this will do what we want, it will leave the tracking urls in place and the groups the mailings were sent to and the actual recipients of the mailings but kill off the tracking data